### PR TITLE
Fixing broken link to API Catalog

### DIFF
--- a/Onboarding/myjohndeere-api-onboarding.ipynb
+++ b/Onboarding/myjohndeere-api-onboarding.ipynb
@@ -461,7 +461,7 @@
         "id": "62MNdbsmeIwT"
       },
       "source": [
-        "Now that you have an access token and organizations are enabled for your application, you are ready to access the MyJohnDeere APIs. The [API Catalog](https://developer.deere.com/#!documentation&doc=myjohndeere%2FapiCatalog.htm&anchor=) is the default starting place that most API sessions with the MyJohnDeere API should begin. The MyJohnDeere API is designed to be [`discoverable`](https://www.baeldung.com/restful-web-service-discoverability). This means that your application should be able to start a session at the API Catalog and find everything else your application needs for your feature via [`links.`](https://developer.deere.com/#!documentation&doc=.%2Fmyjohndeere%2Flinks.htm&anchor=)"
+        "Now that you have an access token and organizations are enabled for your application, you are ready to access the MyJohnDeere APIs. The [API Catalog](https://developer-portal.deere.com/#/myjohndeere/api-catalog) is the default starting place that most API sessions with the MyJohnDeere API should begin. The MyJohnDeere API is designed to be [`discoverable`](https://www.baeldung.com/restful-web-service-discoverability). This means that your application should be able to start a session at the API Catalog and find everything else your application needs for your feature via [`links.`](https://developer.deere.com/#!documentation&doc=.%2Fmyjohndeere%2Flinks.htm&anchor=)"
       ]
     },
     {


### PR DESCRIPTION
Previously, the link would end up getting redirected to
a generic develop with Deere page instead of the API
Catalog.